### PR TITLE
PDF report ingestion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "jsdom": "^29.1.1",
         "node-fetch": "^3.3.2",
         "openai": "^6.7.0",
+        "pdfjs-dist": "^6.1.200",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "reactflow": "^11.10.3",
@@ -52,6 +53,9 @@
         "typescript-eslint": "^8.64.0",
         "vite": "^7.3.6",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=22.15.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1674,6 +1678,271 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.2.tgz",
+      "integrity": "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-x64": "1.0.2",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.2",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.2",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.2",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.2.tgz",
+      "integrity": "sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5721,6 +5990,18 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.1.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
+      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsdom": "^29.1.1",
     "node-fetch": "^3.3.2",
     "openai": "^6.7.0",
+    "pdfjs-dist": "^6.1.200",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "reactflow": "^11.10.3",

--- a/src/features/app/components/SearchForm.tsx
+++ b/src/features/app/components/SearchForm.tsx
@@ -44,6 +44,12 @@ const getTextStats = (text: string) => {
   return { chars, words, isNearLimit, isOverLimit };
 };
 
+const INPUT_MODES = [
+  { value: 'url', label: 'URL', icon: LinkIcon },
+  { value: 'text', label: 'Text', icon: TextFieldsIcon },
+  { value: 'pdf', label: 'PDF', icon: PictureAsPdfIcon },
+] as const;
+
 interface SearchFormProps {
   isLoading: boolean;
   isStreaming: boolean;
@@ -313,172 +319,58 @@ export default function SearchForm({
           },
         }}
       >
-        {/* Input Mode Tabs */}
-        <Box sx={{ 
-          mb: 4,
-          display: 'flex',
-          justifyContent: 'center'
-        }}>
-          <Box sx={{
-            display: 'inline-flex',
-            gap: '2px',
-            p: '3px',
-            background: `linear-gradient(145deg, ${flowVizTheme.colors.surface.rest} 0%, ${flowVizTheme.colors.surface.rest} 100%)`,
-            borderRadius: '16px',
-            border: `1px solid ${flowVizTheme.colors.surface.border.subtle}`,
-            backdropFilter: flowVizTheme.effects.blur.heavy,
-            boxShadow: flowVizTheme.effects.shadows.sm,
-          }}>
-            <Box
-              onClick={() => onInputModeChange('url')}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.25,
-                px: 3.5,
-                py: 1.5,
-                borderRadius: '13px',
-                cursor: 'pointer',
-                transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-                position: 'relative',
-                overflow: 'hidden',
-                background: inputMode === 'url' 
-                  ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
-                  : 'transparent',
-                backdropFilter: inputMode === 'url' ? flowVizTheme.effects.blur.light : 'none',
-                boxShadow: inputMode === 'url'
-                  ? flowVizTheme.effects.shadows.sm
-                  : 'none',
-                border: inputMode === 'url'
-                  ? `1px solid ${flowVizTheme.colors.surface.border.subtle}`
-                  : '1px solid transparent',
-                color: inputMode === 'url'
-                  ? flowVizTheme.colors.text.primary
-                  : flowVizTheme.colors.text.tertiary,
-                '&:hover': {
-                  background: inputMode === 'url'
-                    ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
-                    : flowVizTheme.colors.surface.rest,
-                  color: inputMode === 'url'
-                    ? flowVizTheme.colors.text.primary
-                    : flowVizTheme.colors.text.secondary,
-                },
-              }}
-            >
-              <LinkIcon sx={{ 
-                fontSize: '18px',
-                opacity: inputMode === 'url' ? 0.9 : 0.6,
-                transition: 'all 0.3s ease',
-              }} />
-              <Typography sx={{ 
-                fontSize: '15px',
-                fontWeight: 500,
-                letterSpacing: '0.01em',
-                transition: 'opacity 0.3s ease, color 0.3s ease',
-              }}>
-                Article URL
-              </Typography>
-            </Box>
-            
-            <Box
-              onClick={() => onInputModeChange('text')}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.25,
-                px: 3.5,
-                py: 1.5,
-                borderRadius: '13px',
-                cursor: 'pointer',
-                transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-                position: 'relative',
-                overflow: 'hidden',
-                background: inputMode === 'text' 
-                  ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
-                  : 'transparent',
-                backdropFilter: inputMode === 'text' ? flowVizTheme.effects.blur.light : 'none',
-                boxShadow: inputMode === 'text'
-                  ? flowVizTheme.effects.shadows.sm
-                  : 'none',
-                border: inputMode === 'text'
-                  ? `1px solid ${flowVizTheme.colors.surface.border.subtle}`
-                  : '1px solid transparent',
-                color: inputMode === 'text'
-                  ? flowVizTheme.colors.text.primary
-                  : flowVizTheme.colors.text.tertiary,
-                '&:hover': {
-                  background: inputMode === 'text'
-                    ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
-                    : flowVizTheme.colors.surface.rest,
-                  color: inputMode === 'text'
-                    ? flowVizTheme.colors.text.primary
-                    : flowVizTheme.colors.text.secondary,
-                },
-              }}
-            >
-              <TextFieldsIcon sx={{ 
-                fontSize: '18px',
-                opacity: inputMode === 'text' ? 0.9 : 0.6,
-                transition: 'all 0.3s ease',
-              }} />
-              <Typography sx={{
-                fontSize: '15px',
-                fontWeight: 500,
-                letterSpacing: '0.01em',
-                transition: 'opacity 0.3s ease, color 0.3s ease',
-              }}>
-                Paste Text
-              </Typography>
-            </Box>
-
-            <Box
-              onClick={() => onInputModeChange('pdf')}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.25,
-                px: 3.5,
-                py: 1.5,
-                borderRadius: '13px',
-                cursor: 'pointer',
-                transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-                position: 'relative',
-                overflow: 'hidden',
-                background: inputMode === 'pdf'
-                  ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
-                  : 'transparent',
-                backdropFilter: inputMode === 'pdf' ? flowVizTheme.effects.blur.light : 'none',
-                boxShadow: inputMode === 'pdf' ? flowVizTheme.effects.shadows.sm : 'none',
-                border: inputMode === 'pdf'
-                  ? `1px solid ${flowVizTheme.colors.surface.border.subtle}`
-                  : '1px solid transparent',
-                color: inputMode === 'pdf'
-                  ? flowVizTheme.colors.text.primary
-                  : flowVizTheme.colors.text.tertiary,
-                '&:hover': {
-                  background: inputMode === 'pdf'
-                    ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
-                    : flowVizTheme.colors.surface.rest,
-                  color: inputMode === 'pdf'
-                    ? flowVizTheme.colors.text.primary
-                    : flowVizTheme.colors.text.secondary,
-                },
-              }}
-            >
-              <PictureAsPdfIcon sx={{
-                fontSize: '18px',
-                opacity: inputMode === 'pdf' ? 0.9 : 0.6,
-                transition: 'all 0.3s ease',
-              }} />
-              <Typography sx={{
-                fontSize: '15px',
-                fontWeight: 500,
-                letterSpacing: '0.01em',
-                transition: 'opacity 0.3s ease, color 0.3s ease',
-              }}>
-                PDF Report
-              </Typography>
-            </Box>
+        {/* Input mode — compact monochrome segmented control */}
+        <Box sx={{ mb: 4, display: 'flex', justifyContent: 'center' }}>
+          <Box
+            role="tablist"
+            sx={{
+              display: 'inline-flex',
+              gap: '2px',
+              p: '3px',
+              backgroundColor: flowVizTheme.colors.surface.rest,
+              borderRadius: `${flowVizTheme.borderRadius.lg}px`,
+              border: `1px solid ${flowVizTheme.colors.surface.border.subtle}`,
+            }}
+          >
+            {INPUT_MODES.map(({ value, label, icon: Icon }) => {
+              const active = inputMode === value;
+              return (
+                <Box
+                  key={value}
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => onInputModeChange(value)}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                    px: 1.75,
+                    py: 0.75,
+                    borderRadius: `${flowVizTheme.borderRadius.md}px`,
+                    cursor: 'pointer',
+                    userSelect: 'none',
+                    color: active
+                      ? flowVizTheme.colors.text.primary
+                      : flowVizTheme.colors.text.tertiary,
+                    backgroundColor: active ? flowVizTheme.colors.surface.hover : 'transparent',
+                    transition: `color ${flowVizTheme.motion.fast}, background-color ${flowVizTheme.motion.fast}`,
+                    '&:hover': {
+                      color: active
+                        ? flowVizTheme.colors.text.primary
+                        : flowVizTheme.colors.text.secondary,
+                      backgroundColor: active
+                        ? flowVizTheme.colors.surface.hover
+                        : flowVizTheme.colors.surface.rest,
+                    },
+                  }}
+                >
+                  <Icon sx={{ fontSize: 16 }} />
+                  <Typography sx={{ fontSize: 13, fontWeight: 500, letterSpacing: '0.01em' }}>
+                    {label}
+                  </Typography>
+                </Box>
+              );
+            })}
           </Box>
         </Box>
 
@@ -538,7 +430,7 @@ export default function SearchForm({
                   cursor: pdfBusy ? 'default' : 'pointer',
                   border: `1.5px dashed ${
                     pdfStatus === 'error'
-                      ? flowVizTheme.colors.status.error.border
+                      ? flowVizTheme.colors.surface.border.emphasis
                       : isDragging
                         ? flowVizTheme.colors.surface.border.focus
                         : flowVizTheme.colors.surface.border.subtle
@@ -561,7 +453,7 @@ export default function SearchForm({
               >
                 {pdfBusy ? (
                   <>
-                    <CircularProgress size={32} sx={{ color: flowVizTheme.colors.text.secondary }} />
+                    <CircularProgress size={28} thickness={4} sx={{ color: flowVizTheme.colors.text.tertiary }} />
                     <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
                       {pdfStatus === 'vision'
                         ? 'Analyzing diagrams…'
@@ -578,29 +470,30 @@ export default function SearchForm({
                 ) : pdfStatus === 'done' ? (
                   <>
                     <PictureAsPdfIcon
-                      sx={{ fontSize: 40, color: flowVizTheme.colors.status.success.accent }}
+                      sx={{ fontSize: 36, color: flowVizTheme.colors.text.secondary }}
                     />
                     <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
                       {pdfFileName}
                     </Typography>
-                    <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
-                      {pdfTextStats.chars.toLocaleString()} characters extracted · click to choose a different file
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: pdfTextStats.isOverLimit
+                          ? flowVizTheme.colors.text.secondary
+                          : flowVizTheme.colors.text.tertiary,
+                      }}
+                    >
+                      {pdfTextStats.isOverLimit
+                        ? `Too long — reduce to under ${TEXT_LIMITS.MAX_CHARS.toLocaleString()} characters`
+                        : `${pdfTextStats.chars.toLocaleString()} characters extracted · click to replace`}
                     </Typography>
-                    {pdfTextStats.isOverLimit && (
-                      <Chip
-                        size="small"
-                        color="error"
-                        label={`Too long — reduce to under ${TEXT_LIMITS.MAX_CHARS.toLocaleString()} chars`}
-                        sx={{ mt: 0.5, fontSize: '0.7rem', height: '20px' }}
-                      />
-                    )}
                   </>
                 ) : pdfStatus === 'error' ? (
                   <>
                     <WarningAmberIcon
-                      sx={{ fontSize: 40, color: flowVizTheme.colors.status.error.accent }}
+                      sx={{ fontSize: 36, color: flowVizTheme.colors.text.secondary }}
                     />
-                    <Typography sx={{ color: flowVizTheme.colors.status.error.text, fontWeight: 500 }}>
+                    <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
                       {pdfError}
                     </Typography>
                     <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
@@ -610,9 +503,9 @@ export default function SearchForm({
                 ) : (
                   <>
                     <UploadFileIcon
-                      sx={{ fontSize: 40, color: flowVizTheme.colors.text.secondary }}
+                      sx={{ fontSize: 36, color: flowVizTheme.colors.text.tertiary }}
                     />
-                    <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
+                    <Typography sx={{ color: flowVizTheme.colors.text.secondary, fontWeight: 500 }}>
                       Drop a PDF report here, or click to browse
                     </Typography>
                     <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>

--- a/src/features/app/components/SearchForm.tsx
+++ b/src/features/app/components/SearchForm.tsx
@@ -387,7 +387,7 @@ export default function SearchForm({
               sx={{ mb: 3 }}
             />
           ) : inputMode === 'pdf' ? (
-            <Box sx={{ mb: 3 }}>
+            <Box key="pdf" sx={{ mb: 3 }}>
               <input
                 ref={fileInputRef}
                 type="file"
@@ -426,29 +426,28 @@ export default function SearchForm({
                   px: 3,
                   py: 6,
                   minHeight: 240,
-                  borderRadius: 3,
+                  borderRadius: `${flowVizTheme.borderRadius.md}px`,
                   cursor: pdfBusy ? 'default' : 'pointer',
+                  // Match the URL/Text input fields: same glass background and
+                  // border treatment (default → emphasis on hover, focus on drag).
                   border: `1.5px dashed ${
                     pdfStatus === 'error'
                       ? flowVizTheme.colors.surface.border.emphasis
                       : isDragging
                         ? flowVizTheme.colors.surface.border.focus
-                        : flowVizTheme.colors.surface.border.subtle
+                        : flowVizTheme.colors.surface.border.default
                   }`,
-                  background: isDragging
-                    ? flowVizTheme.colors.surface.hover
-                    : flowVizTheme.colors.surface.rest,
-                  transition: 'all 0.2s ease',
-                  '&:hover': {
-                    borderColor:
-                      pdfBusy
-                        ? undefined
-                        : flowVizTheme.colors.surface.border.default,
-                    background:
-                      pdfBusy
-                        ? undefined
-                        : flowVizTheme.colors.surface.hover,
-                  },
+                  backgroundColor: isDragging
+                    ? flowVizTheme.colors.background.glassLight
+                    : flowVizTheme.colors.background.glass,
+                  // Scope the transition (not `all`) so nothing flashes on toggle.
+                  transition: `border-color ${flowVizTheme.motion.fast}, background-color ${flowVizTheme.motion.fast}`,
+                  '&:hover': pdfBusy
+                    ? undefined
+                    : {
+                        borderColor: flowVizTheme.colors.surface.border.emphasis,
+                        backgroundColor: flowVizTheme.colors.background.glassLight,
+                      },
                 }}
               >
                 {pdfBusy ? (
@@ -516,7 +515,7 @@ export default function SearchForm({
               </Box>
             </Box>
           ) : (
-            <Box sx={{ mb: 3 }}>
+            <Box key="text" sx={{ mb: 3 }}>
               <SearchInputMultiline
                 fullWidth
                 multiline
@@ -527,29 +526,29 @@ export default function SearchForm({
                 onChange={(e) => onTextChange(e.target.value)}
                 sx={{
                   '& .MuiOutlinedInput-notchedOutline': {
-                    borderColor: getTextStats(textContent).isOverLimit 
-                      ? flowVizTheme.colors.status.error.border
-                      : getTextStats(textContent).isNearLimit 
-                        ? flowVizTheme.colors.status.warning.border
+                    borderColor: getTextStats(textContent).isOverLimit
+                      ? flowVizTheme.colors.surface.border.focus
+                      : getTextStats(textContent).isNearLimit
+                        ? flowVizTheme.colors.surface.border.emphasis
                         : flowVizTheme.colors.surface.border.default,
                   },
                 }}
               />
-              
+
               {/* Text Statistics */}
-              <Box sx={{ 
-                display: 'flex', 
-                justifyContent: 'space-between', 
+              <Box sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
                 alignItems: 'center',
                 mt: 1,
                 px: 1
               }}>
                 <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
-                  <Typography variant="caption" sx={{ 
-                    color: getTextStats(textContent).isOverLimit 
-                      ? flowVizTheme.colors.status.error.text
-                      : getTextStats(textContent).isNearLimit 
-                        ? flowVizTheme.colors.status.warning.text
+                  <Typography variant="caption" sx={{
+                    color: getTextStats(textContent).isOverLimit
+                      ? flowVizTheme.colors.text.primary
+                      : getTextStats(textContent).isNearLimit
+                        ? flowVizTheme.colors.text.secondary
                         : flowVizTheme.colors.text.tertiary
                   }}>
                     {getTextStats(textContent).chars.toLocaleString()} / {TEXT_LIMITS.MAX_CHARS.toLocaleString()} characters
@@ -558,15 +557,17 @@ export default function SearchForm({
                     ~{getTextStats(textContent).words.toLocaleString()} words
                   </Typography>
                 </Box>
-                
+
                 {getTextStats(textContent).isNearLimit && (
                   <Chip
                     size="small"
                     label={getTextStats(textContent).isOverLimit ? "Too Long" : "Near Limit"}
-                    color={getTextStats(textContent).isOverLimit ? "error" : "warning"}
                     sx={{
                       fontSize: '0.7rem',
                       height: '20px',
+                      color: flowVizTheme.colors.text.secondary,
+                      backgroundColor: flowVizTheme.colors.surface.hover,
+                      border: `1px solid ${flowVizTheme.colors.surface.border.subtle}`,
                       '& .MuiChip-label': {
                         px: 1
                       }

--- a/src/features/app/components/SearchForm.tsx
+++ b/src/features/app/components/SearchForm.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import {
   Box,
   Container,
@@ -6,11 +7,14 @@ import {
   Alert,
   AlertTitle,
   Chip,
+  CircularProgress,
 } from '@mui/material';
 import LinkIcon from '@mui/icons-material/Link';
 import SearchIcon from '@mui/icons-material/Search';
 import TextFieldsIcon from '@mui/icons-material/TextFields';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { keyframes } from '@mui/system';
 import { SearchInputURL, SearchInputMultiline } from '../../../shared/components/SearchInput';
 import { HeroSubmitButton } from '../../../shared/components/Button';
@@ -43,12 +47,12 @@ const getTextStats = (text: string) => {
 interface SearchFormProps {
   isLoading: boolean;
   isStreaming: boolean;
-  inputMode: 'url' | 'text';
+  inputMode: 'url' | 'text' | 'pdf';
   url: string;
   textContent: string;
   urlError: boolean;
   urlHelperText: string;
-  onInputModeChange: (mode: 'url' | 'text') => void;
+  onInputModeChange: (mode: 'url' | 'text' | 'pdf') => void;
   onUrlChange: (url: string) => void;
   onTextChange: (text: string) => void;
   onSubmit: (e: React.FormEvent) => void;
@@ -69,6 +73,41 @@ export default function SearchForm({
 }: SearchFormProps) {
   // Check if any providers are configured
   const { hasConfiguredProviders, isLoading: providersLoading } = useProviderConfig();
+
+  // PDF ingestion (client-side): extract text in the browser, then feed it
+  // through the existing text path via onTextChange.
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pdfFileName, setPdfFileName] = useState<string | null>(null);
+  const [pdfStatus, setPdfStatus] = useState<'idle' | 'processing' | 'done' | 'error'>('idle');
+  const [pdfProgress, setPdfProgress] = useState<{ page: number; total: number } | null>(null);
+  const [pdfError, setPdfError] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handlePdfFile = async (file: File) => {
+    setPdfFileName(file.name);
+    setPdfStatus('processing');
+    setPdfProgress(null);
+    setPdfError('');
+    onTextChange('');
+
+    try {
+      // Dynamic import keeps pdf.js out of the initial bundle.
+      const { extractPdfText } = await import(
+        '../../../shared/services/pdf/pdfExtractor'
+      );
+      const result = await extractPdfText(file, (p) =>
+        setPdfProgress({ page: p.page, total: p.totalPages })
+      );
+      onTextChange(result.text);
+      setPdfStatus('done');
+    } catch (err) {
+      onTextChange('');
+      setPdfStatus('error');
+      setPdfError(err instanceof Error ? err.message : 'Could not read this PDF.');
+    }
+  };
+
+  const pdfTextStats = getTextStats(textContent);
 
   return (
     <Container
@@ -353,13 +392,62 @@ export default function SearchForm({
                 opacity: inputMode === 'text' ? 0.9 : 0.6,
                 transition: 'all 0.3s ease',
               }} />
-              <Typography sx={{ 
+              <Typography sx={{
                 fontSize: '15px',
                 fontWeight: 500,
                 letterSpacing: '0.01em',
                 transition: 'opacity 0.3s ease, color 0.3s ease',
               }}>
                 Paste Text
+              </Typography>
+            </Box>
+
+            <Box
+              onClick={() => onInputModeChange('pdf')}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.25,
+                px: 3.5,
+                py: 1.5,
+                borderRadius: '13px',
+                cursor: 'pointer',
+                transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+                position: 'relative',
+                overflow: 'hidden',
+                background: inputMode === 'pdf'
+                  ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
+                  : 'transparent',
+                backdropFilter: inputMode === 'pdf' ? flowVizTheme.effects.blur.light : 'none',
+                boxShadow: inputMode === 'pdf' ? flowVizTheme.effects.shadows.sm : 'none',
+                border: inputMode === 'pdf'
+                  ? `1px solid ${flowVizTheme.colors.surface.border.subtle}`
+                  : '1px solid transparent',
+                color: inputMode === 'pdf'
+                  ? flowVizTheme.colors.text.primary
+                  : flowVizTheme.colors.text.tertiary,
+                '&:hover': {
+                  background: inputMode === 'pdf'
+                    ? `linear-gradient(135deg, ${flowVizTheme.colors.surface.active} 0%, ${flowVizTheme.colors.surface.hover} 100%)`
+                    : flowVizTheme.colors.surface.rest,
+                  color: inputMode === 'pdf'
+                    ? flowVizTheme.colors.text.primary
+                    : flowVizTheme.colors.text.secondary,
+                },
+              }}
+            >
+              <PictureAsPdfIcon sx={{
+                fontSize: '18px',
+                opacity: inputMode === 'pdf' ? 0.9 : 0.6,
+                transition: 'all 0.3s ease',
+              }} />
+              <Typography sx={{
+                fontSize: '15px',
+                fontWeight: 500,
+                letterSpacing: '0.01em',
+                transition: 'opacity 0.3s ease, color 0.3s ease',
+              }}>
+                PDF Report
               </Typography>
             </Box>
           </Box>
@@ -377,6 +465,130 @@ export default function SearchForm({
               helperText={urlHelperText}
               sx={{ mb: 3 }}
             />
+          ) : inputMode === 'pdf' ? (
+            <Box sx={{ mb: 3 }}>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/pdf,.pdf"
+                hidden
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handlePdfFile(file);
+                  e.target.value = '';
+                }}
+              />
+              <Box
+                onClick={() => pdfStatus !== 'processing' && fileInputRef.current?.click()}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  if (pdfStatus !== 'processing') setIsDragging(true);
+                }}
+                onDragLeave={(e) => {
+                  e.preventDefault();
+                  setIsDragging(false);
+                }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  setIsDragging(false);
+                  if (pdfStatus === 'processing') return;
+                  const file = e.dataTransfer.files?.[0];
+                  if (file) handlePdfFile(file);
+                }}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  textAlign: 'center',
+                  gap: 1.25,
+                  px: 3,
+                  py: 6,
+                  minHeight: 240,
+                  borderRadius: 3,
+                  cursor: pdfStatus === 'processing' ? 'default' : 'pointer',
+                  border: `1.5px dashed ${
+                    pdfStatus === 'error'
+                      ? flowVizTheme.colors.status.error.border
+                      : isDragging
+                        ? flowVizTheme.colors.surface.border.focus
+                        : flowVizTheme.colors.surface.border.subtle
+                  }`,
+                  background: isDragging
+                    ? flowVizTheme.colors.surface.hover
+                    : flowVizTheme.colors.surface.rest,
+                  transition: 'all 0.2s ease',
+                  '&:hover': {
+                    borderColor:
+                      pdfStatus === 'processing'
+                        ? undefined
+                        : flowVizTheme.colors.surface.border.default,
+                    background:
+                      pdfStatus === 'processing'
+                        ? undefined
+                        : flowVizTheme.colors.surface.hover,
+                  },
+                }}
+              >
+                {pdfStatus === 'processing' ? (
+                  <>
+                    <CircularProgress size={32} sx={{ color: flowVizTheme.colors.text.secondary }} />
+                    <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
+                      Extracting text{pdfFileName ? ` from ${pdfFileName}` : ''}…
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
+                      {pdfProgress
+                        ? `Page ${pdfProgress.page} of ${pdfProgress.total}`
+                        : 'Reading document…'}
+                    </Typography>
+                  </>
+                ) : pdfStatus === 'done' ? (
+                  <>
+                    <PictureAsPdfIcon
+                      sx={{ fontSize: 40, color: flowVizTheme.colors.status.success.accent }}
+                    />
+                    <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
+                      {pdfFileName}
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
+                      {pdfTextStats.chars.toLocaleString()} characters extracted · click to choose a different file
+                    </Typography>
+                    {pdfTextStats.isOverLimit && (
+                      <Chip
+                        size="small"
+                        color="error"
+                        label={`Too long — reduce to under ${TEXT_LIMITS.MAX_CHARS.toLocaleString()} chars`}
+                        sx={{ mt: 0.5, fontSize: '0.7rem', height: '20px' }}
+                      />
+                    )}
+                  </>
+                ) : pdfStatus === 'error' ? (
+                  <>
+                    <WarningAmberIcon
+                      sx={{ fontSize: 40, color: flowVizTheme.colors.status.error.accent }}
+                    />
+                    <Typography sx={{ color: flowVizTheme.colors.status.error.text, fontWeight: 500 }}>
+                      {pdfError}
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
+                      Click to try another file
+                    </Typography>
+                  </>
+                ) : (
+                  <>
+                    <UploadFileIcon
+                      sx={{ fontSize: 40, color: flowVizTheme.colors.text.secondary }}
+                    />
+                    <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
+                      Drop a PDF report here, or click to browse
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
+                      Up to 20&nbsp;MB · 100 pages · text-based PDFs
+                    </Typography>
+                  </>
+                )}
+              </Box>
+            </Box>
           ) : (
             <Box sx={{ mb: 3 }}>
               <SearchInputMultiline
@@ -502,11 +714,23 @@ export default function SearchForm({
             <HeroSubmitButton
               variant="contained"
               type="submit"
-              disabled={!hasConfiguredProviders || isLoading || (inputMode === 'text' && getTextStats(textContent).isOverLimit)}
+              disabled={
+                !hasConfiguredProviders ||
+                isLoading ||
+                pdfStatus === 'processing' ||
+                (inputMode === 'pdf' && pdfStatus !== 'done') ||
+                ((inputMode === 'text' || inputMode === 'pdf') && pdfTextStats.isOverLimit)
+              }
               isLoading={isLoading}
             >
               <SearchIcon sx={{ fontSize: 20, color: flowVizTheme.colors.text.primary }} />
-              <span>{inputMode === 'url' ? 'Analyze Article' : 'Analyze Text'}</span>
+              <span>
+                {inputMode === 'url'
+                  ? 'Analyze Article'
+                  : inputMode === 'pdf'
+                    ? 'Analyze PDF'
+                    : 'Analyze Text'}
+              </span>
             </HeroSubmitButton>
           </Box>
         </Box>

--- a/src/features/app/components/SearchForm.tsx
+++ b/src/features/app/components/SearchForm.tsx
@@ -78,7 +78,9 @@ export default function SearchForm({
   // through the existing text path via onTextChange.
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pdfFileName, setPdfFileName] = useState<string | null>(null);
-  const [pdfStatus, setPdfStatus] = useState<'idle' | 'processing' | 'done' | 'error'>('idle');
+  const [pdfStatus, setPdfStatus] = useState<
+    'idle' | 'processing' | 'vision' | 'done' | 'error'
+  >('idle');
   const [pdfProgress, setPdfProgress] = useState<{ page: number; total: number } | null>(null);
   const [pdfError, setPdfError] = useState('');
   const [isDragging, setIsDragging] = useState(false);
@@ -92,13 +94,39 @@ export default function SearchForm({
 
     try {
       // Dynamic import keeps pdf.js out of the initial bundle.
-      const { extractPdfText } = await import(
+      const { extractPdfText, renderPdfImagePages } = await import(
         '../../../shared/services/pdf/pdfExtractor'
       );
       const result = await extractPdfText(file, (p) =>
         setPdfProgress({ page: p.page, total: p.totalPages })
       );
-      onTextChange(result.text);
+
+      let finalText = result.text;
+
+      // Phase 2: analyze diagrams/screenshots. Only pages with raster images
+      // are rendered, so a text-only report makes no vision call. Best-effort —
+      // if it fails (e.g. Anthropic key not set), fall back to text only.
+      try {
+        const images = await renderPdfImagePages(file, 3);
+        if (images.length > 0) {
+          setPdfStatus('vision');
+          const resp = await fetch('/api/vision-analysis', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ images, articleText: result.text }),
+          });
+          if (resp.ok) {
+            const { analysisText } = await resp.json();
+            if (analysisText) {
+              finalText = `## Diagram Analysis\n\n${analysisText}\n\n## Report Text\n\n${result.text}`;
+            }
+          }
+        }
+      } catch {
+        // Keep the text-only extraction on any vision failure.
+      }
+
+      onTextChange(finalText);
       setPdfStatus('done');
     } catch (err) {
       onTextChange('');
@@ -108,6 +136,7 @@ export default function SearchForm({
   };
 
   const pdfTextStats = getTextStats(textContent);
+  const pdfBusy = pdfStatus === 'processing' || pdfStatus === 'vision';
 
   return (
     <Container
@@ -479,10 +508,10 @@ export default function SearchForm({
                 }}
               />
               <Box
-                onClick={() => pdfStatus !== 'processing' && fileInputRef.current?.click()}
+                onClick={() => !pdfBusy && fileInputRef.current?.click()}
                 onDragOver={(e) => {
                   e.preventDefault();
-                  if (pdfStatus !== 'processing') setIsDragging(true);
+                  if (!pdfBusy) setIsDragging(true);
                 }}
                 onDragLeave={(e) => {
                   e.preventDefault();
@@ -491,7 +520,7 @@ export default function SearchForm({
                 onDrop={(e) => {
                   e.preventDefault();
                   setIsDragging(false);
-                  if (pdfStatus === 'processing') return;
+                  if (pdfBusy) return;
                   const file = e.dataTransfer.files?.[0];
                   if (file) handlePdfFile(file);
                 }}
@@ -506,7 +535,7 @@ export default function SearchForm({
                   py: 6,
                   minHeight: 240,
                   borderRadius: 3,
-                  cursor: pdfStatus === 'processing' ? 'default' : 'pointer',
+                  cursor: pdfBusy ? 'default' : 'pointer',
                   border: `1.5px dashed ${
                     pdfStatus === 'error'
                       ? flowVizTheme.colors.status.error.border
@@ -520,26 +549,30 @@ export default function SearchForm({
                   transition: 'all 0.2s ease',
                   '&:hover': {
                     borderColor:
-                      pdfStatus === 'processing'
+                      pdfBusy
                         ? undefined
                         : flowVizTheme.colors.surface.border.default,
                     background:
-                      pdfStatus === 'processing'
+                      pdfBusy
                         ? undefined
                         : flowVizTheme.colors.surface.hover,
                   },
                 }}
               >
-                {pdfStatus === 'processing' ? (
+                {pdfBusy ? (
                   <>
                     <CircularProgress size={32} sx={{ color: flowVizTheme.colors.text.secondary }} />
                     <Typography sx={{ color: flowVizTheme.colors.text.primary, fontWeight: 500 }}>
-                      Extracting text{pdfFileName ? ` from ${pdfFileName}` : ''}…
+                      {pdfStatus === 'vision'
+                        ? 'Analyzing diagrams…'
+                        : `Extracting text${pdfFileName ? ` from ${pdfFileName}` : ''}…`}
                     </Typography>
                     <Typography variant="caption" sx={{ color: flowVizTheme.colors.text.tertiary }}>
-                      {pdfProgress
-                        ? `Page ${pdfProgress.page} of ${pdfProgress.total}`
-                        : 'Reading document…'}
+                      {pdfStatus === 'vision'
+                        ? 'Reading images with vision analysis'
+                        : pdfProgress
+                          ? `Page ${pdfProgress.page} of ${pdfProgress.total}`
+                          : 'Reading document…'}
                     </Typography>
                   </>
                 ) : pdfStatus === 'done' ? (
@@ -717,7 +750,7 @@ export default function SearchForm({
               disabled={
                 !hasConfiguredProviders ||
                 isLoading ||
-                pdfStatus === 'processing' ||
+                pdfBusy ||
                 (inputMode === 'pdf' && pdfStatus !== 'done') ||
                 ((inputMode === 'text' || inputMode === 'pdf') && pdfTextStats.isOverLimit)
               }

--- a/src/features/app/hooks/useAppState.ts
+++ b/src/features/app/hooks/useAppState.ts
@@ -18,7 +18,7 @@ export const useAppState = () => {
   const [submittedUrl, setSubmittedUrl] = useState('');
   const [textContent, setTextContent] = useState('');
   const [submittedText, setSubmittedText] = useState('');
-  const [inputMode, setInputMode] = useState<'url' | 'text'>('url');
+  const [inputMode, setInputMode] = useState<'url' | 'text' | 'pdf'>('url');
   
   // UI state
   const [showError, setShowError] = useState(false);

--- a/src/shared/services/pdf/pdfExtractor.ts
+++ b/src/shared/services/pdf/pdfExtractor.ts
@@ -1,0 +1,85 @@
+import * as pdfjsLib from 'pdfjs-dist';
+import { PDF_LIMITS, PdfError, validatePdfFile } from './pdfValidation';
+
+export { PDF_LIMITS, PdfError, validatePdfFile } from './pdfValidation';
+export type { PdfErrorCode } from './pdfValidation';
+
+// pdf.js runs its parser in a Web Worker. Vite bundles the worker from this
+// URL and hands back an asset path. Setting it at module load is fine because
+// callers dynamically import() this module, so pdf.js only reaches the browser
+// when the user actually picks a PDF (keeping it out of the initial bundle).
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url
+).toString();
+
+export interface PdfExtractionProgress {
+  page: number;
+  totalPages: number;
+}
+
+export interface PdfExtractionResult {
+  text: string;
+  numPages: number;
+}
+
+/**
+ * Extract the text layer from a PDF entirely in the browser. Throws a PdfError
+ * with a user-facing message for the expected failure modes (not a PDF,
+ * too large/long, encrypted, corrupt, or no selectable text).
+ */
+export async function extractPdfText(
+  file: File,
+  onProgress?: (progress: PdfExtractionProgress) => void
+): Promise<PdfExtractionResult> {
+  await validatePdfFile(file);
+
+  const data = new Uint8Array(await file.arrayBuffer());
+
+  // getDocument returns a loading task; the document is released by destroying
+  // the task (the document proxy itself has no destroy() in pdf.js v6).
+  const loadingTask = pdfjsLib.getDocument({ data });
+  let pdf: pdfjsLib.PDFDocumentProxy;
+  try {
+    pdf = await loadingTask.promise;
+  } catch (err) {
+    if (err && (err as { name?: string }).name === 'PasswordException') {
+      throw new PdfError('ENCRYPTED', 'This PDF is password-protected and cannot be read.');
+    }
+    throw new PdfError('CORRUPT', 'Could not read this PDF. It may be corrupt.');
+  }
+
+  try {
+    if (pdf.numPages > PDF_LIMITS.MAX_PAGES) {
+      throw new PdfError(
+        'TOO_MANY_PAGES',
+        `PDF has ${pdf.numPages} pages. Maximum is ${PDF_LIMITS.MAX_PAGES}.`
+      );
+    }
+
+    const parts: string[] = [];
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const content = await page.getTextContent();
+      const pageText = content.items
+        .map((item) => ('str' in item ? item.str : ''))
+        .join(' ');
+      parts.push(pageText);
+      page.cleanup();
+      onProgress?.({ page: pageNum, totalPages: pdf.numPages });
+    }
+
+    const text = parts.join('\n\n').replace(/[ \t]+\n/g, '\n').trim();
+
+    if (text.replace(/\s/g, '').length < PDF_LIMITS.MIN_TEXT_CHARS) {
+      throw new PdfError(
+        'NO_TEXT',
+        'No selectable text found. This looks like a scanned or image-only PDF.'
+      );
+    }
+
+    return { text, numPages: pdf.numPages };
+  } finally {
+    await loadingTask.destroy();
+  }
+}

--- a/src/shared/services/pdf/pdfExtractor.ts
+++ b/src/shared/services/pdf/pdfExtractor.ts
@@ -23,6 +23,73 @@ export interface PdfExtractionResult {
   numPages: number;
 }
 
+export interface PdfPageImage {
+  base64Data: string;
+  mediaType: string;
+}
+
+// pdf.js operator codes that mean "this page paints a raster image".
+function pageHasRasterImage(fnArray: number[]): boolean {
+  const ops = pdfjsLib.OPS;
+  return fnArray.some(
+    (fn) =>
+      fn === ops.paintImageXObject ||
+      fn === ops.paintInlineImage ||
+      fn === ops.paintImageMaskXObject
+  );
+}
+
+/**
+ * Render the first pages that actually contain raster images (diagrams,
+ * screenshots) to JPEGs, for diagram vision analysis. Text-only pages are
+ * skipped, so a plain text report produces no images and triggers no vision
+ * call. Returns base64 JPEGs sized to stay well within request/image limits.
+ */
+export async function renderPdfImagePages(
+  file: File,
+  maxImages = 3
+): Promise<PdfPageImage[]> {
+  const data = new Uint8Array(await file.arrayBuffer());
+  const loadingTask = pdfjsLib.getDocument({ data });
+  const pdf = await loadingTask.promise;
+  const images: PdfPageImage[] = [];
+
+  try {
+    for (
+      let pageNum = 1;
+      pageNum <= pdf.numPages && images.length < maxImages;
+      pageNum++
+    ) {
+      const page = await pdf.getPage(pageNum);
+      try {
+        const opList = await page.getOperatorList();
+        if (!pageHasRasterImage(opList.fnArray)) continue;
+
+        // Cap the long edge so the encoded image stays small.
+        const baseViewport = page.getViewport({ scale: 1 });
+        const maxEdge = 1400;
+        const scale = Math.min(1.5, maxEdge / Math.max(baseViewport.width, baseViewport.height));
+        const viewport = page.getViewport({ scale });
+
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.ceil(viewport.width);
+        canvas.height = Math.ceil(viewport.height);
+        const canvasContext = canvas.getContext('2d');
+        if (!canvasContext) continue;
+
+        await page.render({ canvas, canvasContext, viewport }).promise;
+        const dataUrl = canvas.toDataURL('image/jpeg', 0.8);
+        images.push({ base64Data: dataUrl.split(',')[1], mediaType: 'image/jpeg' });
+      } finally {
+        page.cleanup();
+      }
+    }
+    return images;
+  } finally {
+    await loadingTask.destroy();
+  }
+}
+
 /**
  * Extract the text layer from a PDF entirely in the browser. Throws a PdfError
  * with a user-facing message for the expected failure modes (not a PDF,

--- a/src/shared/services/pdf/pdfValidation.test.ts
+++ b/src/shared/services/pdf/pdfValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { validatePdfFile, PdfError, PDF_LIMITS } from './pdfValidation';
+
+const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d]; // %PDF-
+
+function makeFile(bytes: number[], name = 'report.pdf'): File {
+  return new File([new Uint8Array(bytes)], name, { type: 'application/pdf' });
+}
+
+describe('validatePdfFile', () => {
+  it('accepts a file with a valid %PDF- header', async () => {
+    const file = makeFile([...PDF_MAGIC, 0x31, 0x2e, 0x34]); // %PDF-1.4
+    await expect(validatePdfFile(file)).resolves.toBeUndefined();
+  });
+
+  it('rejects a file whose bytes are not a PDF', async () => {
+    const file = makeFile([0x50, 0x4b, 0x03, 0x04, 0x00], 'notReallyA.pdf'); // a zip
+    await expect(validatePdfFile(file)).rejects.toBeInstanceOf(PdfError);
+    await expect(validatePdfFile(file)).rejects.toMatchObject({ code: 'INVALID_TYPE' });
+  });
+
+  it('rejects a file that only looks like a PDF by extension', async () => {
+    const file = makeFile([0x25, 0x50, 0x44, 0x00, 0x00]); // %PD.. — not %PDF-
+    await expect(validatePdfFile(file)).rejects.toMatchObject({ code: 'INVALID_TYPE' });
+  });
+
+  it('rejects a file larger than the size limit before reading bytes', async () => {
+    // Fake an oversized File so we don't allocate 20MB in the test. The size
+    // check runs before the byte read, so slice() is never called.
+    const huge = { size: PDF_LIMITS.MAX_BYTES + 1 } as unknown as File;
+    await expect(validatePdfFile(huge)).rejects.toMatchObject({ code: 'TOO_LARGE' });
+  });
+
+  it('PdfError carries a machine-readable code and a message', () => {
+    const err = new PdfError('ENCRYPTED', 'locked');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('ENCRYPTED');
+    expect(err.message).toBe('locked');
+  });
+});

--- a/src/shared/services/pdf/pdfValidation.ts
+++ b/src/shared/services/pdf/pdfValidation.ts
@@ -1,0 +1,49 @@
+// Pure PDF validation — no pdf.js dependency, so it stays cheap to import and test.
+
+export const PDF_LIMITS = {
+  MAX_BYTES: 20 * 1024 * 1024, // 20MB
+  MAX_PAGES: 100,
+  // Below this many non-whitespace chars we treat the PDF as having no usable
+  // text layer (e.g. a scanned/image-only report).
+  MIN_TEXT_CHARS: 20,
+} as const;
+
+export type PdfErrorCode =
+  | 'INVALID_TYPE'
+  | 'TOO_LARGE'
+  | 'TOO_MANY_PAGES'
+  | 'ENCRYPTED'
+  | 'CORRUPT'
+  | 'NO_TEXT';
+
+export class PdfError extends Error {
+  code: PdfErrorCode;
+  constructor(code: PdfErrorCode, message: string) {
+    super(message);
+    this.name = 'PdfError';
+    this.code = code;
+  }
+}
+
+// PDF files start with the magic bytes "%PDF-". Checking the bytes (not just
+// the extension) avoids feeding a mislabelled/hostile file to the parser.
+async function assertPdfMagicBytes(file: Blob): Promise<void> {
+  const header = new Uint8Array(await file.slice(0, 5).arrayBuffer());
+  const isPdf =
+    header[0] === 0x25 && // %
+    header[1] === 0x50 && // P
+    header[2] === 0x44 && // D
+    header[3] === 0x46 && // F
+    header[4] === 0x2d; //   -
+  if (!isPdf) {
+    throw new PdfError('INVALID_TYPE', 'That file is not a valid PDF.');
+  }
+}
+
+export async function validatePdfFile(file: File): Promise<void> {
+  if (file.size > PDF_LIMITS.MAX_BYTES) {
+    const mb = (PDF_LIMITS.MAX_BYTES / (1024 * 1024)).toFixed(0);
+    throw new PdfError('TOO_LARGE', `PDF is too large. Maximum size is ${mb}MB.`);
+  }
+  await assertPdfMagicBytes(file);
+}


### PR DESCRIPTION
Adds the ability to analyze PDF threat reports directly, addressing #13.

## How it works
PDFs are parsed **entirely in the browser** with pdf.js (lazy-loaded, so it's a separate chunk and stays out of the initial bundle). The extracted text is fed through the existing `/api/analyze-stream` text path — **no backend changes**.

- New "PDF" input mode with a drag-and-drop zone
- `%PDF` magic-byte validation (not just the extension), 20MB / 100-page caps
- Page-by-page text extraction with progress, and clear handling of encrypted, corrupt, and scanned/image-only PDFs
- **Diagram vision**: pages that contain raster images are rendered and sent to the existing `/api/vision-analysis`, and the result is prepended to the report text. Text-only PDFs make no vision call.

## Also in here
A small visual pass on the input area to fit the design system: the three-mode selector is now a compact monochrome segmented control, and the PDF/text states use the monochrome surface/text tokens instead of green/red/amber. The dropzone now shares the same glass background as the URL/Text fields.

## Notes
- Diagram vision needs `ANTHROPIC_API_KEY` (the vision endpoint is Anthropic-only) and is best-effort — it falls back to text-only if unavailable.
- An image-PDF analysis spends 2 of the 5-per-5-min streaming rate-limit slots (one vision call + the analysis).

## Testing
Added validation unit tests (129 total). Verified end-to-end in the browser: text-only and diagram PDFs both produce correct attack-flow graphs; dev + production build both clean.